### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
-INSTALL = /usr/bin/install -m 644
-DEST = /usr/share/m17n
-ICONDEST = /usr/share/m17n/icons
-LOCALEDEST = /usr/share/i18n/locales
+INSTALL = /usr/bin/install
+DEST = $(DESTDIR)usr/share/m17n
+ICONDEST = $(DESTDIR)usr/share/m17n/icons
+LOCALEDEST = $(DESTDIR)usr/share/i18n/locales
 
 install:
-	$(INSTALL) *.mim $(DEST)
-	$(INSTALL) *.lnm $(DEST)
-	$(INSTALL) icons/*.png $(ICONDEST)
-	$(INSTALL) cu_RU $(LOCALEDEST)
-	localedef -f UTF-8 -i cu_RU cu_RU
-
+	$(INSTALL) -dm755 $(DEST)
+	$(INSTALL) -dm755 $(ICONDEST)
+	$(INSTALL) -dm755 $(LOCALEDEST)
+	$(INSTALL) -Dm644 *.mim $(DEST)
+	$(INSTALL) -Dm644 *.lnm $(DEST)
+	$(INSTALL) -Dm644 icons/*.png $(ICONDEST)
+	$(INSTALL) -Dm644 cu_RU $(LOCALEDEST)
 
 uninstall:
 	rm -f $(ICONDEST)/cu-kbd.png


### PR DESCRIPTION
Package's Makefile supports only installation into live filesystem, that
is obsolete for many years, but not building a package.

See https://github.com/typiconman/m17n-cu/issues/1 for detail.